### PR TITLE
poison grenade sells for 800 gold.

### DIFF
--- a/packages/junon-io/common/constants.json
+++ b/packages/junon-io/common/constants.json
@@ -3708,7 +3708,7 @@
       "isUnbreakable": true,
       "isCostIndependent": true,
       "cost": {
-        "gold": 750
+        "gold": 1600
       },
       "stats": {
         "damage": 25,


### PR DESCRIPTION
poison grenade to sell for 800 gold for rebalance. small one line change.