### PR TITLE
Stop people spamming sector join

### DIFF
--- a/packages/junon-io/server/entities/game.js
+++ b/packages/junon-io/server/entities/game.js
@@ -2166,6 +2166,18 @@ class Game {
       }
     }
 
+    //check if ip address is already in sector (don't allow more than 2 of the same ip)
+    let ipCount = 0;
+    for(let id in this.players) {
+      if(Helper.getSocketRemoteAddress(this.players[id].socket) === ipAddress) {
+        ipCount ++;
+        if(ipCount >= 2) {
+          this.getSocketUtil().emit(socket, "CantJoin", { message: "You are already in this sector" })
+          return
+        }
+      }
+    }
+
     if (this.hasPlayerAlreadyJoined({ sessionId: socket.sessionId })) return
 
     let uid


### PR DESCRIPTION
A couple of people figured out that they can use the websocket messages from burp suite (or other), and repeat these requests with python or other. I've now limited it based on your ip - you can't join a sector more than twice.
This should cut down on the servers getting full so easily (since the max is only 40)