### PR TITLE
Mining Drill Patch

### DIFF
--- a/packages/junon-io/server/entities/buildings/mining_drill.js
+++ b/packages/junon-io/server/entities/buildings/mining_drill.js
@@ -147,9 +147,9 @@ class MiningDrill extends BaseProcessor {
     }
   }
 
-  canStore(item) {
-      return false;
-  } 
+  canStore(index, item) {
+    return !item
+  }
 
 }
 


### PR DESCRIPTION
Issue:
You could not take stuff out of the mining drill using lmb (dragging it). Mobile players couldn't take it out in general (there only option is to drag which is bugged).
Fix:
Any item being inputted into the mining drill gets blocked. Taking items out of the mining drill is allowed.
This fixes the issue with lmb and mobile players.
Should now help general gameplay.
