### PR TITLE
Improve Title Screen Scrolling

### DIFF
--- a/packages/junon-io/client/stylesheets/mobile.css
+++ b/packages/junon-io/client/stylesheets/mobile.css
@@ -69,11 +69,6 @@
 }
 
 @media only screen and (max-height: 600px) {
-    .main_colony_list {
-        max-height: 160px;
-        overflow-y: scroll;
-    }
-
     #chat_container.vote_mode {
         left: 0px !important;
         top: 0px !important;

--- a/packages/junon-io/client/stylesheets/style.css
+++ b/packages/junon-io/client/stylesheets/style.css
@@ -4321,6 +4321,11 @@ html[lang='ja'] #total_online_count {
     margin-top: 20px;
 }
 
+.main_colony_list, .search_colony_list {
+    height: 50vh;
+    overflow-y: scroll;
+}
+
 .colony_list.list_mode .team_entry_row {
     height: 40px;
     float: none;


### PR DESCRIPTION
This change in the CSS should add clarity.
It allows worlds to be scrolled through without changing the position of the online count, the footer, the menu image background, and the left sidebar.
old: 
<img width="1897" height="900" alt="image" src="https://github.com/user-attachments/assets/ddbb2d1a-d372-4ffb-8b32-32409eda31a5" />
new:
<img width="1901" height="897" alt="image" src="https://github.com/user-attachments/assets/ccea48f6-3f91-4320-8ff2-5df09dbcbb8d" />
